### PR TITLE
update composer file to require bcmath extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     },
     "require": {
         "php": ">=5.5",
-        "malkusch/lock": "^0.4"
+        "malkusch/lock": "^0.4",
+        "ext-bcmath":"*"
     },
     "require-dev": {
         "ext-redis": "^2.2.4",


### PR DESCRIPTION
As BC Math is a required extension. Please include it in the composer requirements. 
