### PR TITLE
Support for zendframework/zend-cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/.idea/
+/composer.lock
+/vendor/

--- a/classes/storage/ZendStorage.php
+++ b/classes/storage/ZendStorage.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace bandwidthThrottle\tokenBucket\storage;
+
+use bandwidthThrottle\tokenBucket\storage\scope\GlobalScope;
+use malkusch\lock\mutex\CASMutex;
+use Zend\Cache\Storage\StorageInterface;
+
+class ZendStorage implements Storage, GlobalScope
+{
+    const PREFIX = 'TokenBucket_';
+
+    /** @var string */
+    protected $key;
+
+    /** @var StorageInterface */
+    protected $storage;
+
+    /** @var CASMutex */
+    protected $mutex;
+
+    /** @var mixed */
+    protected $casToken;
+
+    public function __construct($name, StorageInterface $storage)
+    {
+        $this->key = self::PREFIX . $name;
+        $this->storage = $storage;
+        $this->mutex = new CASMutex();
+    }
+
+    public function getMutex()
+    {
+        return $this->mutex;
+    }
+
+    public function isBootstrapped()
+    {
+        $result = ($this->storage->getItem($this->key) !== null);
+        $this->mutex->notify();
+        return $result;
+    }
+
+    public function bootstrap($microtime)
+    {
+        $this->setMicrotime($microtime);
+    }
+
+    public function remove()
+    {
+        $this->storage->removeItem($this->key);
+    }
+
+    public function letMicrotimeUnchanged()
+    {
+        $this->mutex->notify();
+    }
+
+    public function setMicrotime($microtime)
+    {
+        if ($this->storage->checkAndSetItem($this->casToken, $this->key, $microtime)) {
+            $this->mutex->notify();
+        }
+    }
+
+    public function getMicrotime()
+    {
+        $microtime = $this->storage->getItem($this->key, $success, $casToken);
+
+        if (!$microtime) {
+            throw new StorageException('Microtime not stored.');
+        }
+
+        $this->casToken = $casToken;
+        return (float)$microtime;
+    }
+}

--- a/classes/storage/ZendStorage.php
+++ b/classes/storage/ZendStorage.php
@@ -46,9 +46,11 @@ class ZendStorage implements Storage, GlobalScope
 
     public function bootstrap($microtime)
     {
-        if ($this->storage->setItem($this->key, $microtime)) {
-            $this->mutex->notify();
+        if (!$this->storage->setItem($this->key, $microtime)) {
+            throw new StorageException('Could not bootstrap storage.');
         }
+
+        $this->mutex->notify();
     }
 
     public function remove()

--- a/classes/storage/ZendStorage.php
+++ b/classes/storage/ZendStorage.php
@@ -75,7 +75,13 @@ class ZendStorage implements Storage, GlobalScope
         $microtime = $this->storage->getItem($this->key, $success, $casToken);
 
         if (!$microtime) {
-            throw new StorageException('Microtime not stored.');
+            if ($success) {
+                throw new StorageException('Stored microtime is invalid.');
+            } else {
+                throw new StorageException(
+                    'Failed to retrieve stored microtime. Did you bootstrap the storage before this point?'
+                );
+            }
         }
 
         $this->casToken = $casToken;

--- a/classes/storage/ZendStorage.php
+++ b/classes/storage/ZendStorage.php
@@ -36,14 +36,19 @@ class ZendStorage implements Storage, GlobalScope
 
     public function isBootstrapped()
     {
-        $result = ($this->storage->getItem($this->key) !== null);
-        $this->mutex->notify();
-        return $result;
+        if ($this->storage->getItem($this->key) !== null) {
+            $this->mutex->notify();
+            return true;
+        }
+
+        return false;
     }
 
     public function bootstrap($microtime)
     {
-        $this->setMicrotime($microtime);
+        if ($this->storage->setItem($this->key, $microtime)) {
+            $this->mutex->notify();
+        }
     }
 
     public function remove()

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "predis/predis": "^1",
         "phpunit/phpunit": "^5",
         "mikey179/vfsStream": "^1.5.0",
-        "php-mock/php-mock-phpunit": "^1"
+        "php-mock/php-mock-phpunit": "^1",
+        "zendframework/zend-cache": "^2.8"
     },
     "archive": {
         "exclude": ["/tests"]


### PR DESCRIPTION
I've written a zend-cache storage type `ZendStorage` for a project where I have no direct access to our memcache(d) instance. This allows any storage medium that this package defines. Is this aggregate storage a thing you would like to see in your package? If so I can finish this PR up with some tests.