### PR TITLE
Fix File Storage not working on Windows

### DIFF
--- a/classes/storage/FileStorage.php
+++ b/classes/storage/FileStorage.php
@@ -81,7 +81,6 @@ final class FileStorage implements Storage, GlobalScope
     
     public function bootstrap($microtime)
     {
-        $this->open(); // remove() could have deleted the file.
         $this->setMicrotime($microtime);
     }
     


### PR DESCRIPTION
Opening bucket in bootstrap method causes fwrite to fail with error: write of 8 bytes failed with errno=13 Permission denied 

https://github.com/bandwidth-throttle/token-bucket/issues/21