### PR TITLE
Implicit -> explicit to int

### DIFF
--- a/classes/BlockingConsumer.php
+++ b/classes/BlockingConsumer.php
@@ -69,7 +69,7 @@ final class BlockingConsumer
             }
 
             // sleep at least 1 millisecond.
-            usleep(max(1000, $seconds * 1000000));
+            usleep(max(1000, (int)($seconds * 1000000)));
         }
     }
     


### PR DESCRIPTION
fix Implicit conversion from float to int, by making it explicit.

Gives depricates warning in Php 8.1
"Implicit incompatible float to int conversion is deprecated."
https://www.php.net/releases/8.1/en.php