### PR TITLE
upgrade to malkusch/lock 3 for use with Php84

### DIFF
--- a/classes/BlockingConsumer.php
+++ b/classes/BlockingConsumer.php
@@ -69,7 +69,7 @@ final class BlockingConsumer
             }
 
             // sleep at least 1 millisecond.
-            usleep(max(1000, $seconds * 1000000));
+            usleep(max(1000, (int)($seconds * 1000000)));
         }
     }
     


### PR DESCRIPTION
due to  malkusch/lock 2.3.0 requires php >=7.4 <8.4,
so allow the package to use malkusch/lock 3